### PR TITLE
pop up menu on USR1

### DIFF
--- a/menutray
+++ b/menutray
@@ -467,6 +467,8 @@ use utf8;
 use strict;
 use Gtk${gtk_v} ('-init');
 
+\$SIG\{USR1\} = \\\&show_icon_menu;
+
 my \$menu = 'Gtk${gtk_v}::Menu'->new;
 my \$icon = 'Gtk${gtk_v}::StatusIcon'->new;
 


### PR DESCRIPTION
this allows opening the menu via a keyboard shortcut; example command I use in openbox:
sh -c "pkill -u $(whoami) -f menutray -SIGUSR1"