### PR TITLE
icon tooltip and title

### DIFF
--- a/menutray
+++ b/menutray
@@ -215,6 +215,8 @@ my %CONFIG = (
     icon_size              => [16, 16],
     missing_image          => 'gtk-missing-image',
     menutray_icon          => 'start-here',
+    menutray_title         => 'menutray',
+    menutray_tooltip       => 'Applications - ' . `hostname | tr -d '\n'`,
     gdk_interpolation_type => 'hyper',
 
     VERSION => $version,
@@ -469,6 +471,17 @@ use Gtk${gtk_v} ('-init');
 
 my \$menu = 'Gtk${gtk_v}::Menu'->new;
 my \$icon = 'Gtk${gtk_v}::StatusIcon'->new;
+
+my \$menutray_title = "$CONFIG{menutray_title}";
+
+if (\$menutray_title) {
+    \$icon->set_title(\$menutray_title);
+    \$icon->set_name('');
+}
+
+my \$menutray_tooltip = "$CONFIG{menutray_tooltip}";
+
+\$icon->set_tooltip(\$menutray_tooltip) if \$menutray_tooltip;
 
 \$icon->set_from_icon_name('$CONFIG{menutray_icon}');
 \$icon->set_visible(1);


### PR DESCRIPTION
Support for an arbitrary menutray icon title allows you to control the icon's position (sort order) in panels and notification areas that support sorting (e.g. tint2). For example, setting the title to something like `00_menutray` would always place menutray before any other icons.